### PR TITLE
A basic setup.py is needed for pip install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+setup()
+


### PR DESCRIPTION
This allows us to install the wrappers using `pip install --editable`
for example.